### PR TITLE
Fix Typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains official binaries for the io.net - Follow the instructi
       ```
       chmod +x ionet-setup.sh && ./ionet-setup.sh
       ```
-   ##### Note - incase curl command fails:
+   ##### Note - In case curl command fails:
     - Install `curl`:
          ```
          sudo apt install curl
@@ -68,7 +68,7 @@ This repository contains official binaries for the io.net - Follow the instructi
     ./io_net_launch_binary_mac
     ```
 
-- Trouble Shooting (Optional)
+- Troubleshooting (Optional)
 
     - If you encounter an error message like `bad CPU type in executable`, it likely indicates that you are running software designed for an Intel processor on an Apple Silicon device. To resolve this issue, you'll need to install Rosetta 2, which enables support for Intel processors to run within Docker on Apple Silicon devices.
 
@@ -76,7 +76,7 @@ This repository contains official binaries for the io.net - Follow the instructi
         softwareupdate --install-rosetta
       ```
 
-    - After finished the Rosetta install, rerun the excute command again.
+    - After finishing the Rosetta install, rerun the execute command again.
 
       ```
       ./io_net_launch_binary_mac


### PR DESCRIPTION
Corrected typographical errors in the README.md for improved clarity.

Changes:
"incase" to "in case"
"Trouble Shooting" to "Troubleshooting"
"finished" to "finishing"
"excute" to "execute"
These changes enhance the readability of the document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typos and improved clarity in the setup and troubleshooting instructions for `io.net` binaries in the README.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->